### PR TITLE
config validation for http events

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,19 +312,19 @@ To add this plugin to your package.json:
 
 **Using npm:**
 ```bash
-npm install serverless-openapi-documentation --save-dev
+npm install @apalchys/serverless-openapi-documentation --save-dev
 ```
 
 **Using Yarn:**
 ```bash
-yarn add serverless-openapi-documentation --dev
+yarn add @apalchys/serverless-openapi-documentation --dev
 ```
 
 Next you need to add the plugin to the `plugins` section of your `serverless.yml` file.
 
 ```yml
 plugins:
-  - serverless-openapi-documentation
+  - '@apalchys/serverless-openapi-documentation'
 ```
 
 You can confirm the plugin is correctly installed by running:

--- a/src/ServerlessOpenApiDocumentation.ts
+++ b/src/ServerlessOpenApiDocumentation.ts
@@ -69,6 +69,12 @@ export class ServerlessOpenApiDocumentation {
         documentation: { type: 'object' },
       },
     });
+
+    this.serverless.configSchemaHandler.defineFunctionEventProperties('aws', 'http', {
+      properties: {
+        documentation: { type: 'object' },
+      },
+    });
   }
 
   log: ILog = (...str: string[]) => {


### PR DESCRIPTION
Hi, just a quick PR with the aim of doing two things:

- updating the name of this version of the plugin in the readme
- supporting config validation for http events.

Whilst this plugin does exactly what I need it to do, there are warnings when I start serverless which would be nice if they were removed.

```
Warning: Invalid configuration encountered
  at 'functions.{name}.events.0.http': unrecognized property 'documentation'
```

I noticed that there is already validation for `httpApi` events but not `http` events. So this is what I have added!

Thanks
